### PR TITLE
Update create_patched_sdk.sh to work with new versions of tbd

### DIFF
--- a/create_patched_sdk.sh
+++ b/create_patched_sdk.sh
@@ -30,14 +30,9 @@ fi
 
 version="v1"
 
-archs_option=("--replace-archs" armv7 armv7s arm64)
+archs_option=("--archs" armv7 armv7s arm64)
 tbd_options=("--allow-private-objc-symbols" "--ignore-missing-exports")
 write_options=("--maintain-directories" "--replace-path-extension")
-
-no_overwrite="--no-overwrite"
-if [ $# -gt 2 ] && [ "$3" != '-' ]; then
-    no_overwrite=""
-fi
 
 no_warnings=""
 if [ $# -gt 3 ] && [ "$4" != '-' ]; then
@@ -142,7 +137,7 @@ if [ -d "$device_support_dir" ] && [ "$use_simulator" == "-" ]; then
         cp -R "$xcode_default_sdk_path/"* "$sdks_output_path_single_sdk_path"
 
         "$tbd_tool" -p -r "$symbols_actual_path" \
-                    -o "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System" \
+                    -o "${write_options[@]}" "$sdks_output_path_single_sdk_path/System" \
                     $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
`--replace-archs` was renamed to `--archs`, and `--no-overwrite` no longer exists.

`./create_patched_sdk.sh ` can be used to generate SDKs for 11.0-11.3.1, and `./create_patched_sdk.sh no` can be used to generate the 11.4 SDK (using Xcode 9.4.1).