### PR TITLE
Provide instructions to find older SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # theos/sdks
 This repository contains patched iOS SDKs containing private symbols. These were removed from official SDKs starting in Xcode 7.3 and the iOS 9.3 SDK.
 
-To get older SDKs, you can "Show Package Contents" of the appropriate Xcode version, and then browse to `Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs`.
+To get older SDKs on macOS, you can "Show Package Contents" of the appropriate Xcode version, and then browse to `Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs`.
 
 To use with Theos, [download this repo](https://github.com/theos/sdks/archive/master.zip), extract, and copy whichever SDKs you desire into `$THEOS/sdks/`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # theos/sdks
 This repository contains patched iOS SDKs containing private symbols. These were removed from official SDKs starting in Xcode 7.3 and the iOS 9.3 SDK.
 
+To get older SDKs, you can "Show Package Contents" of the appropriate Xcode version, and then browse to `Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs`.
+
 To use with Theos, [download this repo](https://github.com/theos/sdks/archive/master.zip), extract, and copy whichever SDKs you desire into `$THEOS/sdks/`.
 
 Generated using [create_patched_sdk.sh](create_patched_sdk.sh) and inoahdev’s [tbd v2.2](https://github.com/inoahdev/tbd/releases/tag/2.2) using binaries retrieved from iOS Device Support directory.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds instructions to the README as to where to find older SDKs. The Theos installation guide just tells users to go here, but for example, I wanted the iOS 8 SDK to compile an older project.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
N/A