### PR TITLE
Syntax fixes to iOS and tvOS create bash scripts

### DIFF
--- a/create_patched_sdk.py
+++ b/create_patched_sdk.py
@@ -69,21 +69,7 @@ def removeDirectory(dir):
     return True
 
 def main(argv):
-    theos_path_env = os.environ.get("THEOS")
-    if theos_path_env is None:
-        print("The path of environment-variable $THEOS doesn't exist.")
-        print("Please run 'export THEOS=<theos path here>' before running this program")
-
-        exit(1)
-
-    theos_path = Path(theos_path_env)
-    if not theos_path.exists() or not theos_path.is_dir():
-        print("No directory exists at path of environment-variable $THEOS")
-        exit(1)
-
-    output_path = theos_path / "sdks"
     parser = argparse.ArgumentParser(description="Apple Platform SDK Generator Python Script", add_help=True)
-
     parser.add_argument("-a", "--archs", nargs='+', help="A list of archs to replace ones in SDK", required=False)
     parser.add_argument("--dirs", help='A list of dirs to recurse while parsing inside SDK', default=DIRS, nargs='+', required=False)
     parser.add_argument("--ignore-warnings", help="Ignore any warnings from tbd", action='store_true', default=False, required=False)
@@ -99,6 +85,42 @@ def main(argv):
     parser.add_argument('-x', "--xcode-path", help=f'Path to Xcode-Installation. Default location is {XCODE_PATH}', required=False)
 
     args = parser.parse_args()
+
+    output_path = args.output_path
+    if output_path is None:
+        theos_path_env = os.environ.get("THEOS")
+
+        if theos_path_env is None:
+            print("No Theos installation found.")
+            print("Please either install Theos or provide a path to an sdks directory")
+
+            exit(1)
+
+        theos_path = Path(theos_path_env)
+
+        if not theos_path.exists():
+            print("No Theos installation found.")
+            print("Please either install Theos or provide a path to an sdks directory")
+
+            exit(1)
+
+        elif not theos_path.is_dir():
+            print("Theos does not appear to be installed correctly.")
+            print("Please either reinstall Theos or provide a path to an sdks directory")
+
+            exit(1)
+
+        output_path = theos_path / "sdks"
+
+    else:
+        output_path = Path(output_path)
+        output_path.mkdir(mode=0o666, parents=True, exist_ok=True)
+        if not output_path.is_dir():
+            print(f'{output_path} does not appear to be a directory.')
+            print("Please provide a path to an sdks directory")
+
+            exit(1)
+
     tbd_path_string = TBD_PATH
 
     if args.tbd_path is not None:
@@ -112,23 +134,17 @@ def main(argv):
 
         exit(1)
 
-    if not tbd_path.is_file():
+    elif not tbd_path.is_file():
         print("Your tbd path is not a path to a file")
         print(f"A tbd executable file was expected at {tbd_path}")
 
         exit(1)
 
-    if not os.access(tbd_path.as_posix(), os.X_OK):
+    elif not os.access(tbd_path.as_posix(), os.X_OK):
         print("Your tbd file is not executable")
         print(f"Please run 'chmod +x {tbd_path}'")
 
         exit(1)
-
-    did_provide_output_path = args.output_path is not None
-    if did_provide_output_path:
-        output_path = Path(args.output_path)
-
-    output_path.mkdir(mode=0o666, parents=False, exist_ok=True)
 
     did_provide_archs = args.archs is not None
     did_provide_targets = args.targets is not None
@@ -137,11 +153,11 @@ def main(argv):
         print("Error: Both --keep-archs and --replace-archs were provided")
         exit(1)
 
-    if args.keep_targets and did_provide_targets:
+    elif args.keep_targets and did_provide_targets:
         print("Error: Both --keep-targets and --replace-targets were provided")
         exit(1)
 
-    if did_provide_archs and did_provide_targets:
+    elif did_provide_archs and did_provide_targets:
         print("Error: Both --replace-archs and --replace-targets were provided")
         exit(1)
 
@@ -262,7 +278,7 @@ def main(argv):
 
         exit(1)
 
-    if not xcode_path.is_dir():
+    elif not xcode_path.is_dir():
         print("Your Xcode Application Path does not point to a directory")
         print(f"The Xcode Application Path Directory was expected at {xcode_path}")
 
@@ -309,7 +325,7 @@ def main(argv):
 
     if not xcode_sdk_version:
         print("No SDK pointing to the default SDK was found")
-        print("The default sdk exists at path {xcode_default_sdk_path}")
+        print(f"The default sdk exists at path {xcode_default_sdk_path}")
 
         exit(1)
 
@@ -359,13 +375,13 @@ def main(argv):
 
                     continue
 
-                if not sdk_write_path.is_dir():
+                elif not sdk_write_path.is_dir():
                     print(f"Warning: A non-directory exists at write-path for SDK for iOS {symbols_ios_version}. Skipping")
                     print(f"SDK for iOS {symbols_ios_version} is at {sdk_write_path}")
 
                     continue
 
-                if not removeDirectory(sdk_write_path):
+                elif not removeDirectory(sdk_write_path):
                     continue
 
             if xcode_sdk_version != symbols_ios_version:
@@ -441,7 +457,7 @@ def main(argv):
 
             exit(1)
 
-        if not simulator_version_path.is_file():
+        elif not simulator_version_path.is_file():
             print("The iOS Simulator RuntimeRoot directory's SystemVersion.plist is not a file. Please re-install the simulator")
             print(f"The iOS Simulator RuntimeRoot directory's SystemVersion.plist is at {simulator_version_path}")
 

--- a/create_patched_sdk.py
+++ b/create_patched_sdk.py
@@ -69,7 +69,21 @@ def removeDirectory(dir):
     return True
 
 def main(argv):
+    theos_path_env = os.environ.get("THEOS")
+    if theos_path_env is None:
+        print("The path of environment-variable $THEOS doesn't exist.")
+        print("Please run 'export THEOS=<theos path here>' before running this program")
+
+        exit(1)
+
+    theos_path = Path(theos_path_env)
+    if not theos_path.exists() or not theos_path.is_dir():
+        print("No directory exists at path of environment-variable $THEOS")
+        exit(1)
+
+    output_path = theos_path / "sdks"
     parser = argparse.ArgumentParser(description="Apple Platform SDK Generator Python Script", add_help=True)
+
     parser.add_argument("-a", "--archs", nargs='+', help="A list of archs to replace ones in SDK", required=False)
     parser.add_argument("--dirs", help='A list of dirs to recurse while parsing inside SDK', default=DIRS, nargs='+', required=False)
     parser.add_argument("--ignore-warnings", help="Ignore any warnings from tbd", action='store_true', default=False, required=False)
@@ -85,42 +99,6 @@ def main(argv):
     parser.add_argument('-x', "--xcode-path", help=f'Path to Xcode-Installation. Default location is {XCODE_PATH}', required=False)
 
     args = parser.parse_args()
-
-    output_path = args.output_path
-    if output_path is None:
-        theos_path_env = os.environ.get("THEOS")
-
-        if theos_path_env is None:
-            print("No Theos installation found.")
-            print("Please either install Theos or provide a path to an sdks directory")
-
-            exit(1)
-
-        theos_path = Path(theos_path_env)
-
-        if not theos_path.exists():
-            print("No Theos installation found.")
-            print("Please either install Theos or provide a path to an sdks directory")
-
-            exit(1)
-
-        elif not theos_path.is_dir():
-            print("Theos does not appear to be installed correctly.")
-            print("Please either reinstall Theos or provide a path to an sdks directory")
-
-            exit(1)
-
-        output_path = theos_path / "sdks"
-
-    else:
-        output_path = Path(output_path)
-        output_path.mkdir(mode=0o666, parents=True, exist_ok=True)
-        if not output_path.is_dir():
-            print(f'{output_path} does not appear to be a directory.')
-            print("Please provide a path to an sdks directory")
-
-            exit(1)
-
     tbd_path_string = TBD_PATH
 
     if args.tbd_path is not None:
@@ -134,17 +112,23 @@ def main(argv):
 
         exit(1)
 
-    elif not tbd_path.is_file():
+    if not tbd_path.is_file():
         print("Your tbd path is not a path to a file")
         print(f"A tbd executable file was expected at {tbd_path}")
 
         exit(1)
 
-    elif not os.access(tbd_path.as_posix(), os.X_OK):
+    if not os.access(tbd_path.as_posix(), os.X_OK):
         print("Your tbd file is not executable")
         print(f"Please run 'chmod +x {tbd_path}'")
 
         exit(1)
+
+    did_provide_output_path = args.output_path is not None
+    if did_provide_output_path:
+        output_path = Path(args.output_path)
+
+    output_path.mkdir(mode=0o666, parents=False, exist_ok=True)
 
     did_provide_archs = args.archs is not None
     did_provide_targets = args.targets is not None
@@ -153,11 +137,11 @@ def main(argv):
         print("Error: Both --keep-archs and --replace-archs were provided")
         exit(1)
 
-    elif args.keep_targets and did_provide_targets:
+    if args.keep_targets and did_provide_targets:
         print("Error: Both --keep-targets and --replace-targets were provided")
         exit(1)
 
-    elif did_provide_archs and did_provide_targets:
+    if did_provide_archs and did_provide_targets:
         print("Error: Both --replace-archs and --replace-targets were provided")
         exit(1)
 
@@ -278,7 +262,7 @@ def main(argv):
 
         exit(1)
 
-    elif not xcode_path.is_dir():
+    if not xcode_path.is_dir():
         print("Your Xcode Application Path does not point to a directory")
         print(f"The Xcode Application Path Directory was expected at {xcode_path}")
 
@@ -325,7 +309,7 @@ def main(argv):
 
     if not xcode_sdk_version:
         print("No SDK pointing to the default SDK was found")
-        print(f"The default sdk exists at path {xcode_default_sdk_path}")
+        print("The default sdk exists at path {xcode_default_sdk_path}")
 
         exit(1)
 
@@ -375,13 +359,13 @@ def main(argv):
 
                     continue
 
-                elif not sdk_write_path.is_dir():
+                if not sdk_write_path.is_dir():
                     print(f"Warning: A non-directory exists at write-path for SDK for iOS {symbols_ios_version}. Skipping")
                     print(f"SDK for iOS {symbols_ios_version} is at {sdk_write_path}")
 
                     continue
 
-                elif not removeDirectory(sdk_write_path):
+                if not removeDirectory(sdk_write_path):
                     continue
 
             if xcode_sdk_version != symbols_ios_version:
@@ -457,7 +441,7 @@ def main(argv):
 
             exit(1)
 
-        elif not simulator_version_path.is_file():
+        if not simulator_version_path.is_file():
             print("The iOS Simulator RuntimeRoot directory's SystemVersion.plist is not a file. Please re-install the simulator")
             print(f"The iOS Simulator RuntimeRoot directory's SystemVersion.plist is at {simulator_version_path}")
 

--- a/create_patched_sdk.sh
+++ b/create_patched_sdk.sh
@@ -118,10 +118,7 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
             continue
         fi
 
-        symbols_path_basename=$(basename "$symbols_path")
-        symbols_path_basename_array=($symbols_path_basename)
-
-        ios_version=${symbols_path_basename_array[0]}
+        ios_version="$(basename "$symbols_path" | grep -o "\d\+\(\.\d\+\)\{1,2\}")"
         sdk_name=$(printf "iPhoneOS%s.sdk" $ios_version)
 
         symbols_actual_path="$symbols_path/Symbols/System"

--- a/create_patched_sdk.sh
+++ b/create_patched_sdk.sh
@@ -92,7 +92,7 @@ xcode_default_sdk_path="$xcode_developer_path/Platforms/iPhoneOS.platform/Develo
 preferred_xcode_sdk_path=""
 
 for xcode_sdk_path in "$xcode_developer_path/Platforms/iPhoneOS.platform/Developer/SDKs/"*; do
-    xcode_sdk_real=$(cd "$(dirname "$xcode_sdk_path")"; pwd -P)/$(basename "$xcode_sdk_path")
+    xcode_sdk_real=$(realpath "$xcode_sdk_path")
 
     if [[ $xcode_sdk_real == $xcode_default_sdk_path ]]; then
         preferred_xcode_sdk_path=$xcode_sdk_path

--- a/create_patched_sdk.sh
+++ b/create_patched_sdk.sh
@@ -61,14 +61,12 @@ if [[ $# -lt 5 ]] || ignored $tbd_tool; then
 else
     tbd_exists=$(command -v "$tbd_tool")
     if [[ -z $tbd_exists ]]; then
-        printf "Provided tbd-tool (%s) doesn't exist\n" "$tbd_tool"
+        printf "Provided tbd-tool (%s) doesn't exist or isn't executable\n" "$tbd_tool"
         exit 1
     fi
 fi
 
 use_simulator="$1"
-device_support_dir="$HOME/Library/Developer/Xcode/iOS DeviceSupport/"
-
 if [[ $# -lt 1 ]]; then
     use_simulator="-"
 fi
@@ -91,11 +89,10 @@ if ! [[ -d $xcode_sim_runtime_path ]]; then
 fi
 xcode_default_sdk_path="$xcode_developer_path/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
 
-xcode_sdk_paths="$xcode_developer_path/Platforms/iPhoneOS.platform/Developer/SDKs/*"
 preferred_xcode_sdk_path=""
 
-for xcode_sdk_path in "$xcode_sdk_paths"; do
-    xcode_sdk_real=$(realpath $xcode_sdk_path)
+for xcode_sdk_path in "$xcode_developer_path/Platforms/iPhoneOS.platform/Developer/SDKs/"*; do
+    xcode_sdk_real=$(cd "$(dirname "$xcode_sdk_path")"; pwd -P)/$(basename "$xcode_sdk_path")
 
     if [[ $xcode_sdk_real == $xcode_default_sdk_path ]]; then
         preferred_xcode_sdk_path=$xcode_sdk_path
@@ -114,7 +111,8 @@ xcode_sdk_ios_version=${xcode_sdk_ios_version%????} # Remove '.sdk' at back of s
 
 sdks_output_path_single_sdk_path=""
 
-if [[ -d $device_support_dir]] && ignored $use_simulator; then
+device_support_dir="$HOME/Library/Developer/Xcode/iOS DeviceSupport/"
+if [[ -d $device_support_dir ]] && ignored $use_simulator; then
     for symbols_path in "$device_support_dir"*; do
         if ! [[ -d $symbols_path ]]; then
             continue

--- a/create_patched_sdk.sh
+++ b/create_patched_sdk.sh
@@ -36,7 +36,7 @@ fi
 # tbd info
 version="v3"
 
-archs_option=("--replace-archs" armv7 armv7s arm64)
+archs_option=("--replace-archs" armv7 armv7s arm64 arm64e)
 tbd_options=("--ignore-clients" "--ignore-undefineds" "--allow-private-objc-symbols" "--ignore-missing-exports")
 write_options=("--preserve-subdirs" "--replace-path-extension")
 

--- a/create_patched_sdk_tvos.sh
+++ b/create_patched_sdk_tvos.sh
@@ -126,20 +126,20 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
 
         symbols_actual_path="$symbols_path/Symbols/System"
         if ! [[ -d $symbols_actual_path ]]; then
-            printf "Symbols for TVOS %s don't exist\n" "$tvos_version"
+            printf "Symbols for tvOS %s don't exist\n" "$tvos_version"
             continue
         fi
 
         sdks_output_path_single_sdk_path="$sdks_output_path/$sdk_name"
         if [[ -d $sdks_output_path_single_sdk_path ]]; then
-            printf 'SDK for TVOS %s already exists\n' "$tvos_version"
+            printf 'SDK for tvOS %s already exists\n' "$tvos_version"
             continue
         fi
 
-        printf 'Creating SDK for TVOS %s ...\n' "$tvos_version"
+        printf 'Creating SDK for tvOS %s ...\n' "$tvos_version"
 
         if [[ $xcode_sdk_tvos_version != $tvos_version ]]; then
-            printf "Warning: Xcode SDK for TVOS %s will be used as a base for sdk for TVOS %s\n" $xcode_sdk_tvos_version "$tvos_version"
+            printf "Warning: Xcode SDK for tvOS %s will be used as a base for sdk for tvOS %s\n" $xcode_sdk_tvos_version "$tvos_version"
         fi
 
         mkdir -p "$sdks_output_path_single_sdk_path"
@@ -150,7 +150,7 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
                     $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 
         if [[ $? -ne 0 ]]; then
-            printf 'Failed to create tbds from Symbols directory for TVOS %s\n' $tvos_version
+            printf 'Failed to create tbds from Symbols directory for tvOS %s\n' $tvos_version
         fi
     done
 else
@@ -160,11 +160,11 @@ else
 
     sdks_output_path_single_sdk_path="$sdks_output_path/$preferred_xcode_sdk_name"
     if [[ -d $sdks_output_path_single_sdk_path ]]; then
-        printf 'SDK for TVOS %s already exists\n' $xcode_sdk_tvos_version
+        printf 'SDK for tvOS %s already exists\n' $xcode_sdk_tvos_version
         exit 1
     fi
 
-    printf 'Creating sdk for TVOS %s ...\n' "$xcode_sdk_tvos_version"
+    printf 'Creating sdk for tvOS %s ...\n' "$xcode_sdk_tvos_version"
 
     mkdir -p "$sdks_output_path_single_sdk_path"
     cp -R "$xcode_default_sdk_path/"* "$sdks_output_path_single_sdk_path"
@@ -180,6 +180,6 @@ else
     "$tbd_tool" "${parse_paths[@]}" "${write_paths[@]}" $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 
     if [[ $? -ne 0 ]]; then
-        printf 'Failed to create tbds from AppleTVSimulator runtime for TVOS %s\n' $xcode_sdk_tvos_version
+        printf 'Failed to create tbds from AppleTVSimulator runtime for tvOS %s\n' $xcode_sdk_tvos_version
     fi
 fi

--- a/create_patched_sdk_tvos.sh
+++ b/create_patched_sdk_tvos.sh
@@ -142,9 +142,9 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
         mkdir -p "$sdks_output_path_single_sdk_path"
         cp -R "$xcode_default_sdk_path/"* "$sdks_output_path_single_sdk_path"
 
-        "$tbd_tool" -p -r all "$symbols_actual_path" \
-                    -o "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System" \
-                    $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
+        "$tbd_tool" \
+            -p $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version -r all "$symbols_actual_path" \
+            -o "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System"
 
         if [[ $? -ne 0 ]]; then
             printf 'Failed to create tbds from Symbols directory for tvOS %s\n' $tvos_version

--- a/create_patched_sdk_tvos.sh
+++ b/create_patched_sdk_tvos.sh
@@ -92,7 +92,7 @@ xcode_default_sdk_path="$xcode_developer_path/Platforms/AppleTVOS.platform/Devel
 
 preferred_xcode_sdk_path=""
 for xcode_sdk_path in "$xcode_developer_path/Platforms/AppleTVOS.platform/Developer/SDKs/"*; do
-    xcode_sdk_real=$(cd "$(dirname "$xcode_sdk_path")"; pwd -P)/$(basename "$xcode_sdk_path")
+    xcode_sdk_real=$(realpath "$xcode_sdk_path")
 
     if [[ $xcode_sdk_real == $xcode_default_sdk_path ]]; then
         preferred_xcode_sdk_path=$xcode_sdk_path
@@ -145,12 +145,6 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
         mkdir -p "$sdks_output_path_single_sdk_path"
         cp -R "$xcode_default_sdk_path/"* "$sdks_output_path_single_sdk_path"
 
-        science="$tbd_tool -p -r all $symbols_actual_path \
-                    -o ${write_options[@]} $no_overwrite $sdks_output_path_single_sdk_path/System \
-                    $no_warnings ${tbd_options[@]} ${archs_option[@]} -v $version"
-
-        echo $science
-
         "$tbd_tool" -p -r all "$symbols_actual_path" \
                     -o "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System" \
                     $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
@@ -182,10 +176,6 @@ else
     write_paths=("-o" "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/Developer"
                  "-o" "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System"
                  "-o" "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/Library")
-
-    science="$tbd_tool ${parse_paths[@]} ${write_paths[@]} $no_warnings ${tbd_options[@]} ${archs_option[@]} -v $version"
-
-    echo $science
 
     "$tbd_tool" "${parse_paths[@]}" "${write_paths[@]}" $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 

--- a/create_patched_sdk_tvos.sh
+++ b/create_patched_sdk_tvos.sh
@@ -118,10 +118,7 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
             continue
         fi
 
-        symbols_path_basename=$(basename "$symbols_path")
-        symbols_path_basename_array=($symbols_path_basename)
-
-        tvos_version=${symbols_path_basename_array[0]}
+        tvos_version="$(basename "$symbols_path" | grep -o "\d\+\(\.\d\+\)\{1,2\}")"
         sdk_name=$(printf "AppleTVOS%s.sdk" $tvos_version)
 
         symbols_actual_path="$symbols_path/Symbols/System"

--- a/create_patched_sdk_tvos.sh
+++ b/create_patched_sdk_tvos.sh
@@ -65,14 +65,12 @@ if [[ $# -lt 5 ]] || ignored $tbd_tool; then
 else
     tbd_exists=$(command -v "$tbd_tool")
     if [[ -z $tbd_exists ]]; then
-        printf "Provided tbd-tool (%s) doesn't exist\n" "$tbd_tool"
+        printf "Provided tbd-tool (%s) doesn't exist or isn't executable\n" "$tbd_tool"
         exit 1
     fi
 fi
 
 use_simulator="$1"
-device_support_dir="$HOME/Library/Developer/Xcode/tvOS DeviceSupport/"
-
 if [[ $# -lt 1 ]]; then
     use_simulator="-"
 fi
@@ -89,14 +87,12 @@ if [[ -z $xcode_developer_path ]]; then
     exit 1
 fi
 
-xcode_sim_runtime_path="$xcode_developer_path/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot"
+xcode_sim_runtime_path="$xcode_developer_path/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot"
 xcode_default_sdk_path="$xcode_developer_path/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk"
 
-xcode_sdk_paths="$xcode_developer_path/Platforms/AppleTVOS.platform/Developer/SDKs/*"
-
 preferred_xcode_sdk_path=""
-for xcode_sdk_path in "$xcode_sdk_paths"; do
-    xcode_sdk_real=$(realpath $xcode_sdk_path)
+for xcode_sdk_path in "$xcode_developer_path/Platforms/AppleTVOS.platform/Developer/SDKs/"*; do
+    xcode_sdk_real=$(cd "$(dirname "$xcode_sdk_path")"; pwd -P)/$(basename "$xcode_sdk_path")
 
     if [[ $xcode_sdk_real == $xcode_default_sdk_path ]]; then
         preferred_xcode_sdk_path=$xcode_sdk_path
@@ -110,11 +106,12 @@ fi
 
 preferred_xcode_sdk_name=$(basename $preferred_xcode_sdk_path)
 
-xcode_sdk_ios_version=${preferred_xcode_sdk_name:8} # Remove 'iPhoneOS' in front of sdk name
-xcode_sdk_ios_version=${xcode_sdk_ios_version%????} # Remove '.sdk' at back of sdk name
+xcode_sdk_tvos_version=${preferred_xcode_sdk_name:9} # Remove 'AppleTVOS' in front of sdk name
+xcode_sdk_tvos_version=${xcode_sdk_tvos_version%????} # Remove '.sdk' at back of sdk name
 
 sdks_output_path_single_sdk_path=""
 
+device_support_dir="$HOME/Library/Developer/Xcode/tvOS DeviceSupport/"
 if [[ -d $device_support_dir ]] && ignored $use_simulator; then
     for symbols_path in "$device_support_dir"*; do
         if ! [[ -d $symbols_path ]]; then
@@ -124,25 +121,25 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
         symbols_path_basename=$(basename "$symbols_path")
         symbols_path_basename_array=($symbols_path_basename)
 
-        ios_version=${symbols_path_basename_array[0]}
-        sdk_name=$(printf "AppleTVOS%s.sdk" $ios_version)
+        tvos_version=${symbols_path_basename_array[0]}
+        sdk_name=$(printf "AppleTVOS%s.sdk" $tvos_version)
 
         symbols_actual_path="$symbols_path/Symbols/System"
         if ! [[ -d $symbols_actual_path ]]; then
-            printf "Symbols for iOS %s don't exist\n" "$ios_version"
+            printf "Symbols for TVOS %s don't exist\n" "$tvos_version"
             continue
         fi
 
         sdks_output_path_single_sdk_path="$sdks_output_path/$sdk_name"
         if [[ -d $sdks_output_path_single_sdk_path ]]; then
-            printf 'SDK for iOS %s already exists\n' "$ios_version"
+            printf 'SDK for TVOS %s already exists\n' "$tvos_version"
             continue
         fi
 
-        printf 'Creating SDK for iOS %s ...\n' "$ios_version"
+        printf 'Creating SDK for TVOS %s ...\n' "$tvos_version"
 
-        if [[ $xcode_sdk_ios_version != $ios_version ]]; then
-            printf "Warning: Xcode SDK for iOS %s will be used as a base for sdk for iOS %s\n" $xcode_sdk_ios_version "$ios_version"
+        if [[ $xcode_sdk_tvos_version != $tvos_version ]]; then
+            printf "Warning: Xcode SDK for TVOS %s will be used as a base for sdk for TVOS %s\n" $xcode_sdk_tvos_version "$tvos_version"
         fi
 
         mkdir -p "$sdks_output_path_single_sdk_path"
@@ -152,14 +149,14 @@ if [[ -d $device_support_dir ]] && ignored $use_simulator; then
                     -o ${write_options[@]} $no_overwrite $sdks_output_path_single_sdk_path/System \
                     $no_warnings ${tbd_options[@]} ${archs_option[@]} -v $version"
 
-        #echo $science
+        echo $science
 
         "$tbd_tool" -p -r all "$symbols_actual_path" \
                     -o "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System" \
                     $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 
         if [[ $? -ne 0 ]]; then
-            printf 'Failed to create tbds from Symbols directory for iOS %s\n' $ios_version
+            printf 'Failed to create tbds from Symbols directory for TVOS %s\n' $tvos_version
         fi
     done
 else
@@ -169,11 +166,11 @@ else
 
     sdks_output_path_single_sdk_path="$sdks_output_path/$preferred_xcode_sdk_name"
     if [[ -d $sdks_output_path_single_sdk_path ]]; then
-        printf 'SDK for iOS %s already exists\n' $xcode_sdk_ios_version
+        printf 'SDK for TVOS %s already exists\n' $xcode_sdk_tvos_version
         exit 1
     fi
 
-    printf 'Creating sdk for iOS %s ...\n' "$xcode_sdk_ios_version"
+    printf 'Creating sdk for TVOS %s ...\n' "$xcode_sdk_tvos_version"
 
     mkdir -p "$sdks_output_path_single_sdk_path"
     cp -R "$xcode_default_sdk_path/"* "$sdks_output_path_single_sdk_path"
@@ -186,9 +183,13 @@ else
                  "-o" "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/System"
                  "-o" "${write_options[@]}" $no_overwrite "$sdks_output_path_single_sdk_path/Library")
 
+    science="$tbd_tool ${parse_paths[@]} ${write_paths[@]} $no_warnings ${tbd_options[@]} ${archs_option[@]} -v $version"
+
+    echo $science
+
     "$tbd_tool" "${parse_paths[@]}" "${write_paths[@]}" $no_warnings "${tbd_options[@]}" "${archs_option[@]}" -v $version
 
     if [[ $? -ne 0 ]]; then
-        printf 'Failed to create tbds from iPhoneSimulator runtime for iOS %s\n' $xcode_sdk_ios_version
+        printf 'Failed to create tbds from AppleTVSimulator runtime for TVOS %s\n' $xcode_sdk_tvos_version
     fi
 fi


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

- fix bug where `xcode_sdk_paths` was improperly expanded, resulting in finding no Xcode SDKs
- add `arm64e` to iPhoneOS ARCHS to match all recent SDKs
- support new DeviceSupport directory names
  - old style: `16.5.1 (20F75) arm64e`
  - new style: `iPhone14,6 16.5.1 (20F75)`
- fix shell syntax error when using real device symbols
- update tvOS script to use tvOS terminology
- minimize diff between `create_patched_sdk.sh` and `create_patched_sdk_tvos.sh` for maintainability 

Does this close any currently open issues?
------------------------------------------
no

Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
no

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.0.40.1)`